### PR TITLE
fix initDatabase: don't let lose leader on joining

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ class Leader extends EventEmitter {
       .catch((err) => {
         if (err.message !== 'ns not found') throw err;
       })
-      .then((collection) => collection ? this.db.collection(this.key) : this.db.createCollection(this.key))
+      .then((cursor) => cursor.hasNext() ? this.db.collection(this.key) : this.db.createCollection(this.key))
       .then((collection) => collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: this.options.ttl / 1000 }));
   }
 

--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ class Leader extends EventEmitter {
   initDatabase() {
     return this.db.command({ ping: 1 })
       .then(() => this.db.executeDbAdminCommand({ setParameter: 1, ttlMonitorSleepSecs: 1 }))
-      .then(() => this.db.dropCollection(this.key))
+      .then(() => this.db.listCollections({ name: this.key }))
       .catch((err) => {
         if (err.message !== 'ns not found') throw err;
       })
-      .then(() => this.db.createCollection(this.key))
+      .then((collection) => collection ? this.db.collection(this.key) : this.db.createCollection(this.key))
       .then((collection) => collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: this.options.ttl / 1000 }));
   }
 


### PR DESCRIPTION
Do initDatabase() without dropping "leader-*" collection, so we don't lose current leader when new nodes are joining.